### PR TITLE
fix: add per-host circuit breaker so unreachable sources can't starve worker

### DIFF
--- a/MetaMorphAPI/Program.cs
+++ b/MetaMorphAPI/Program.cs
@@ -9,7 +9,7 @@ if (builder.Environment.IsProduction())
     builder.WebHost.UseSentry();
 }
 
-builder.Services.AddHttpClient();
+builder.SetupHttpClient();
 
 // Configure CORS
 builder.Services.AddCors(options =>

--- a/MetaMorphAPI/Services/Cache/RedisKeys.cs
+++ b/MetaMorphAPI/Services/Cache/RedisKeys.cs
@@ -13,6 +13,10 @@ public static class RedisKeys
     public static RedisKey GetETagKey(string hash, string format) => new($"etag:{hash}_{format}_{VERSION}");
     public static RedisKey GetValidKey(string hash, string format) => new($"valid:{hash}_{format}_{VERSION}");
 
+    // Per-host circuit breaker (source reachability)
+    public static RedisKey GetUnhealthyHostKey(string host) => new($"unhealthyhost:{host}_{VERSION}");
+    public static RedisKey GetHostFailureKey(string host) => new($"hostfailures:{host}_{VERSION}");
+
     public static string GetFormatString(MediaType mediaType, ImageFormat imageFormat, VideoFormat videoFormat) =>
         mediaType switch
         {

--- a/MetaMorphAPI/Services/ConversionBackgroundService.cs
+++ b/MetaMorphAPI/Services/ConversionBackgroundService.cs
@@ -1,5 +1,6 @@
 using MetaMorphAPI.Services.Cache;
 using MetaMorphAPI.Services.Queue;
+using Prometheus;
 
 namespace MetaMorphAPI.Services;
 
@@ -11,10 +12,16 @@ public class ConversionBackgroundService(
     ConverterService converterService,
     DownloadService downloadService,
     ICacheService cacheService,
+    IHostHealthService hostHealth,
     int concurrentConversions,
     ILogger<ConversionBackgroundService> logger)
     : BackgroundService
 {
+    // No host label: a custom realm can point at any catalyst, so the host set is unbounded.
+    private static readonly Counter DOWNLOAD_SKIPPED = Metrics.CreateCounter(
+        "dcl_metamorph_download_skipped_total",
+        "Number of conversions skipped because the source host's circuit was open.");
+
     protected override async Task ExecuteAsync(CancellationToken ct)
     {
         // Create a list to hold the consumer tasks.
@@ -41,12 +48,37 @@ public class ConversionBackgroundService(
                 // Await the next job from the queue.
                 var conversionJob = await queue.Dequeue(ct);
 
+                var host = TryGetHost(conversionJob.URL);
+
+                // Fast-fail jobs whose source host is currently unreachable, instead of blocking
+                // this worker slot on a download that will time out.
+                if (host != null && await hostHealth.IsHostUnhealthy(host))
+                {
+                    logger.LogWarning("Skipping conversion {Hash}: source host {Host} circuit is open",
+                        conversionJob.Hash, host);
+                    DOWNLOAD_SKIPPED.Inc();
+                    continue;
+                }
+
                 logger.LogInformation(
                     "Processing conversion {Hash} from {URL} (ImageFormat: {ImageFormat}, VideoFormat: {VideoFormat})",
                     conversionJob.Hash, conversionJob.URL, conversionJob.ImageFormat, conversionJob.VideoFormat);
 
-                // Download and convert
-                var downloadResult = await downloadService.DownloadFile(conversionJob.URL, conversionJob.Hash);
+                // Download (recording host reachability so repeated failures open the circuit)
+                (string path, string? eTag, TimeSpan? maxAge) downloadResult;
+                try
+                {
+                    downloadResult = await downloadService.DownloadFile(conversionJob.URL, conversionJob.Hash, ct);
+                }
+                catch when (host != null && !ct.IsCancellationRequested)
+                {
+                    await hostHealth.RecordFailure(host);
+                    throw;
+                }
+
+                if (host != null) await hostHealth.RecordSuccess(host);
+
+                // Convert
                 var (convertedPath, duration, format, fileType) =
                     await converterService.Convert(downloadResult.path, conversionJob.Hash, conversionJob.ImageFormat,
                         conversionJob.VideoFormat);
@@ -73,4 +105,7 @@ public class ConversionBackgroundService(
             }
         }
     }
+
+    private static string? TryGetHost(string url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri.Host : null;
 }

--- a/MetaMorphAPI/Services/ConversionBackgroundService.cs
+++ b/MetaMorphAPI/Services/ConversionBackgroundService.cs
@@ -72,7 +72,16 @@ public class ConversionBackgroundService(
                 }
                 catch when (host != null && !ct.IsCancellationRequested)
                 {
-                    await hostHealth.RecordFailure(host);
+                    // Don't let breaker bookkeeping (e.g. Redis unreachable) mask the real download error.
+                    try
+                    {
+                        await hostHealth.RecordFailure(host);
+                    }
+                    catch (Exception bookkeepingError)
+                    {
+                        logger.LogWarning(bookkeepingError, "Failed to record host failure for {Host}", host);
+                    }
+
                     throw;
                 }
 

--- a/MetaMorphAPI/Services/DownloadService.cs
+++ b/MetaMorphAPI/Services/DownloadService.cs
@@ -12,10 +12,11 @@ public class DownloadService(string tempDirectory, HttpClient httpClient, long m
     /// <summary>
     /// Downloads a file from URL and saves it to <see cref="tempDirectory"/> with <see cref="hash"/> filename.
     /// </summary>
-    public async Task<(string path, string? eTag, TimeSpan? maxAge)> DownloadFile(string url, string hash)
+    public async Task<(string path, string? eTag, TimeSpan? maxAge)> DownloadFile(string url, string hash,
+        CancellationToken ct = default)
     {
         using var response =
-            await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+            await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
             throw new Exception(
@@ -39,16 +40,16 @@ public class DownloadService(string tempDirectory, HttpClient httpClient, long m
                 BUFFER_SIZE,
                 FileOptions.Asynchronous | FileOptions.SequentialScan
             );
-            await using var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            await using var responseStream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
             long totalBytesRead = 0;
             int bytesRead;
-            while ((bytesRead = await responseStream.ReadAsync(buffer.AsMemory()).ConfigureAwait(false)) > 0)
+            while ((bytesRead = await responseStream.ReadAsync(buffer.AsMemory(), ct).ConfigureAwait(false)) > 0)
             {
                 totalBytesRead += bytesRead;
                 if (totalBytesRead > maxFileSizeBytes)
                     throw new Exception(
                         $"Downloaded data exceeded the maximum allowed size of {maxFileSizeBytes} bytes.");
-                await fs.WriteAsync(buffer.AsMemory(0, bytesRead));
+                await fs.WriteAsync(buffer.AsMemory(0, bytesRead), ct);
             }
         }
         catch

--- a/MetaMorphAPI/Services/IHostHealthService.cs
+++ b/MetaMorphAPI/Services/IHostHealthService.cs
@@ -1,0 +1,24 @@
+namespace MetaMorphAPI.Services;
+
+/// <summary>
+/// Tracks the reachability of source hosts so the worker can fast-fail jobs whose
+/// host is currently unreachable, instead of blocking a worker slot on a download
+/// that will time out. Implemented as a per-host circuit breaker.
+/// </summary>
+public interface IHostHealthService
+{
+    /// <summary>
+    /// Returns true if the host's circuit is currently open (recently seen as unreachable).
+    /// </summary>
+    Task<bool> IsHostUnhealthy(string host);
+
+    /// <summary>
+    /// Records a successful download from the host, closing the circuit.
+    /// </summary>
+    Task RecordSuccess(string host);
+
+    /// <summary>
+    /// Records a failed download from the host. Opens the circuit once failures cross the threshold.
+    /// </summary>
+    Task RecordFailure(string host);
+}

--- a/MetaMorphAPI/Services/InMemoryHostHealthService.cs
+++ b/MetaMorphAPI/Services/InMemoryHostHealthService.cs
@@ -1,0 +1,49 @@
+using System.Collections.Concurrent;
+
+namespace MetaMorphAPI.Services;
+
+/// <summary>
+/// In-memory per-host circuit breaker for single-process (local) mode where Redis isn't available.
+/// </summary>
+public class InMemoryHostHealthService(int failureThreshold, TimeSpan failureWindow, TimeSpan cooldown)
+    : IHostHealthService
+{
+    private readonly ConcurrentDictionary<string, HostState> _state = new();
+
+    public Task<bool> IsHostUnhealthy(string host)
+    {
+        var open = _state.TryGetValue(host, out var s) && s.OpenUntil > DateTime.UtcNow;
+        return Task.FromResult(open);
+    }
+
+    public Task RecordSuccess(string host)
+    {
+        _state.TryRemove(host, out _);
+        return Task.CompletedTask;
+    }
+
+    public Task RecordFailure(string host)
+    {
+        _state.AddOrUpdate(host,
+            _ =>
+            {
+                var now = DateTime.UtcNow;
+                var openUntil = failureThreshold <= 1 ? now + cooldown : DateTime.MinValue;
+                return new HostState(1, now + failureWindow, openUntil);
+            },
+            (_, s) =>
+            {
+                var now = DateTime.UtcNow;
+                var withinWindow = now <= s.WindowEnd;
+                var count = withinWindow ? s.Failures + 1 : 1;
+                // Refresh the sliding window on every failure so the counter stays alive through a
+                // sustained outage (mirrors the Redis-backed implementation).
+                var windowEnd = now + failureWindow;
+                var openUntil = count >= failureThreshold ? now + cooldown : s.OpenUntil;
+                return new HostState(count, windowEnd, openUntil);
+            });
+        return Task.CompletedTask;
+    }
+
+    private readonly record struct HostState(long Failures, DateTime WindowEnd, DateTime OpenUntil);
+}

--- a/MetaMorphAPI/Services/InMemoryHostHealthService.cs
+++ b/MetaMorphAPI/Services/InMemoryHostHealthService.cs
@@ -8,6 +8,10 @@ namespace MetaMorphAPI.Services;
 public class InMemoryHostHealthService(int failureThreshold, TimeSpan failureWindow, TimeSpan cooldown)
     : IHostHealthService
 {
+    // Above this many tracked hosts, opportunistically drop idle entries to bound growth under
+    // sustained unique-host churn (local-dev only; distributed mode uses Redis with key TTLs).
+    private const int MaxTrackedHosts = 4096;
+
     private readonly ConcurrentDictionary<string, HostState> _state = new();
 
     public Task<bool> IsHostUnhealthy(string host)
@@ -42,7 +46,27 @@ public class InMemoryHostHealthService(int failureThreshold, TimeSpan failureWin
                 var openUntil = count >= failureThreshold ? now + cooldown : s.OpenUntil;
                 return new HostState(count, windowEnd, openUntil);
             });
+
+        EvictIdleIfCrowded();
         return Task.CompletedTask;
+    }
+
+    private void EvictIdleIfCrowded()
+    {
+        if (_state.Count <= MaxTrackedHosts)
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        foreach (var (host, state) in _state)
+        {
+            // Drop fully-idle hosts: window elapsed and circuit closed.
+            if (now > state.WindowEnd && now > state.OpenUntil)
+            {
+                _state.TryRemove(host, out _);
+            }
+        }
     }
 
     private readonly record struct HostState(long Failures, DateTime WindowEnd, DateTime OpenUntil);

--- a/MetaMorphAPI/Services/RedisHostHealthService.cs
+++ b/MetaMorphAPI/Services/RedisHostHealthService.cs
@@ -26,13 +26,20 @@ public class RedisHostHealthService(
     public async Task RecordFailure(string host)
     {
         var failureKey = RedisKeys.GetHostFailureKey(host);
-        var failures = await redis.StringIncrementAsync(failureKey);
 
-        // Refresh the sliding window on every failure so the counter stays alive through a
-        // sustained outage. Otherwise the counter expires mid-outage and the circuit needs a
-        // fresh batch of (expensive) failures to re-trip after each cooldown.
-        await redis.KeyExpireAsync(failureKey, failureWindow);
+        // INCR and the window refresh run in a single MULTI/EXEC, so a crash between them can't
+        // leave the counter without a TTL. The window is refreshed on every failure so the counter
+        // stays alive through a sustained outage (otherwise it expires mid-outage and the circuit
+        // needs a fresh batch of expensive failures to re-trip after each cooldown).
+        var transaction = redis.CreateTransaction();
+        var incrementTask = transaction.StringIncrementAsync(failureKey);
+        _ = transaction.KeyExpireAsync(failureKey, failureWindow);
+        await transaction.ExecuteAsync();
 
+        var failures = await incrementTask;
+
+        // The conditional open is a separate command (a transaction can't branch on the INCR result).
+        // If a crash lands between EXEC and this SET, the circuit simply opens on the next failure.
         if (failures >= failureThreshold)
         {
             logger.LogWarning(

--- a/MetaMorphAPI/Services/RedisHostHealthService.cs
+++ b/MetaMorphAPI/Services/RedisHostHealthService.cs
@@ -1,0 +1,44 @@
+using MetaMorphAPI.Services.Cache;
+using StackExchange.Redis;
+
+namespace MetaMorphAPI.Services;
+
+/// <summary>
+/// Redis-backed per-host circuit breaker. State is shared across all worker tasks and
+/// persists across the conversion dedup window, so once a host is known unreachable every
+/// worker skips it (including re-requested jobs) until the cooldown elapses and a probe succeeds.
+/// </summary>
+public class RedisHostHealthService(
+    IDatabase redis,
+    int failureThreshold,
+    TimeSpan failureWindow,
+    TimeSpan cooldown,
+    ILogger<RedisHostHealthService> logger) : IHostHealthService
+{
+    public Task<bool> IsHostUnhealthy(string host) => redis.KeyExistsAsync(RedisKeys.GetUnhealthyHostKey(host));
+
+    public async Task RecordSuccess(string host)
+    {
+        // Close the circuit and reset the failure counter (also handles a successful half-open probe).
+        await redis.KeyDeleteAsync([RedisKeys.GetHostFailureKey(host), RedisKeys.GetUnhealthyHostKey(host)]);
+    }
+
+    public async Task RecordFailure(string host)
+    {
+        var failureKey = RedisKeys.GetHostFailureKey(host);
+        var failures = await redis.StringIncrementAsync(failureKey);
+
+        // Refresh the sliding window on every failure so the counter stays alive through a
+        // sustained outage. Otherwise the counter expires mid-outage and the circuit needs a
+        // fresh batch of (expensive) failures to re-trip after each cooldown.
+        await redis.KeyExpireAsync(failureKey, failureWindow);
+
+        if (failures >= failureThreshold)
+        {
+            logger.LogWarning(
+                "Opening circuit for host {Host} after {Failures} failures (cooldown {Cooldown}s)",
+                host, failures, cooldown.TotalSeconds);
+            await redis.StringSetAsync(RedisKeys.GetUnhealthyHostKey(host), "1", cooldown, When.Always);
+        }
+    }
+}

--- a/MetaMorphAPI/Utils/BootstrapHelper.cs
+++ b/MetaMorphAPI/Utils/BootstrapHelper.cs
@@ -25,6 +25,23 @@ public static class BootstrapHelper
     private const string KTX2_MIME_TYPE = "image/ktx2";
     private const string MP4_MIME_TYPE = "video/mp4";
 
+    /// <summary>
+    /// Registers the default HttpClient with a short connection timeout so downloads from
+    /// unreachable hosts fail fast at the connect phase, without shortening the overall
+    /// transfer budget that large (but reachable) files may need.
+    /// </summary>
+    public static void SetupHttpClient(this IHostApplicationBuilder builder)
+    {
+        var connectTimeout = TimeSpan.FromSeconds(builder.GetRequiredConfig<int>("MetaMorph:ConnectTimeoutSeconds"));
+
+        builder.Services.AddHttpClient();
+        builder.Services.ConfigureHttpClientDefaults(b =>
+            b.ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+            {
+                ConnectTimeout = connectTimeout
+            }));
+    }
+
     public static void SetupSerilog(this IHostApplicationBuilder builder)
     {
         // Bootstrap the static Serilog logger for use in Program.cs
@@ -83,9 +100,35 @@ public static class BootstrapHelper
                 sp.GetRequiredService<ConverterService>(),
                 sp.GetRequiredService<DownloadService>(),
                 sp.GetRequiredService<ICacheService>(),
+                sp.GetRequiredService<IHostHealthService>(),
                 builder.GetRequiredConfig<int>("MetaMorph:ConcurrentConversions"),
                 sp.GetRequiredService<ILogger<ConversionBackgroundService>>()
             ));
+    }
+
+    /// <summary>
+    /// Registers the per-host circuit breaker. Redis-backed when available (shared across worker
+    /// tasks), otherwise in-memory for single-process local mode.
+    /// </summary>
+    private static void RegisterHostHealth(IHostApplicationBuilder builder, bool redisBacked)
+    {
+        var threshold = builder.GetRequiredConfig<int>("MetaMorph:HostHealth:FailureThreshold");
+        var window = TimeSpan.FromSeconds(builder.GetRequiredConfig<int>("MetaMorph:HostHealth:FailureWindowSeconds"));
+        var cooldown = TimeSpan.FromSeconds(builder.GetRequiredConfig<int>("MetaMorph:HostHealth:CooldownSeconds"));
+
+        if (redisBacked)
+        {
+            builder.Services.AddSingleton<IHostHealthService>(sp =>
+                new RedisHostHealthService(
+                    sp.GetRequiredService<IDatabase>(),
+                    threshold, window, cooldown,
+                    sp.GetRequiredService<ILogger<RedisHostHealthService>>()));
+        }
+        else
+        {
+            builder.Services.AddSingleton<IHostHealthService>(_ =>
+                new InMemoryHostHealthService(threshold, window, cooldown));
+        }
     }
 
     internal static void SetupLocalCache(this WebApplicationBuilder builder)
@@ -105,6 +148,8 @@ public static class BootstrapHelper
                 sp.GetRequiredService<ILogger<LocalCacheService>>()));
 
         builder.Services.AddSingleton<IConversionQueue, LocalConversionQueue>();
+
+        RegisterHostHealth(builder, redisBacked: false);
     }
 
     public static void SetupRemoteCache(this IHostApplicationBuilder builder, bool setupS3, bool setupCdn)
@@ -117,6 +162,9 @@ public static class BootstrapHelper
 
         // Redis
         builder.Services.AddSingleton<IDatabase>(_ => ConnectionMultiplexer.Connect(redisConnectionString).GetDatabase());
+
+        // Per-host circuit breaker (shared across worker tasks via Redis)
+        RegisterHostHealth(builder, redisBacked: true);
 
         // SQS
         builder.Services.AddAWSService<IAmazonSQS>();

--- a/MetaMorphAPI/appsettings.json
+++ b/MetaMorphAPI/appsettings.json
@@ -7,7 +7,13 @@
     "ConcurrentConversions": 1,
     "MinMaxAgeMinutes": 5,
     "WaitTimeoutSeconds": 20,
-    "WaitPoolIntervalMilliseconds": 1000
+    "WaitPoolIntervalMilliseconds": 1000,
+    "ConnectTimeoutSeconds": 5,
+    "HostHealth": {
+      "FailureThreshold": 3,
+      "FailureWindowSeconds": 300,
+      "CooldownSeconds": 60
+    }
   },
   "AWS": {
     "Region": "us-east-1"

--- a/MetaMorphWorker/Program.cs
+++ b/MetaMorphWorker/Program.cs
@@ -9,7 +9,7 @@ if (builder.Environment.IsProduction())
     builder.WebHost.UseSentry();
 }
 
-builder.Services.AddHttpClient();
+builder.SetupHttpClient();
 
 builder.SetupSerilog();
 builder.SetupConverter();

--- a/Tests/ConversionBackgroundServiceTests.cs
+++ b/Tests/ConversionBackgroundServiceTests.cs
@@ -1,0 +1,198 @@
+using System.Net;
+using MetaMorphAPI.Enums;
+using MetaMorphAPI.Services;
+using MetaMorphAPI.Services.Cache;
+using MetaMorphAPI.Services.Queue;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Tests;
+
+/// <summary>
+/// Integration tests for the worker loop's per-host circuit-breaker behavior: skipping jobs from
+/// unhealthy hosts, and recording host reachability based on download success/failure.
+/// </summary>
+[TestFixture]
+public class ConversionBackgroundServiceTests
+{
+    private const string HOST = "catalyst.dcl.one";
+    private const string URL = "https://catalyst.dcl.one/content/asset.png";
+    private const string HASH = "test-hash";
+
+    private string _tempDir = null!;
+    private Mock<IConversionQueue> _queue = null!;
+    private Mock<ICacheService> _cache = null!;
+    private Mock<IHostHealthService> _health = null!;
+    private readonly ConversionJob _job = new(HASH, URL, ImageFormat.UASTC, VideoFormat.MP4);
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "metamorph-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+
+        _queue = new Mock<IConversionQueue>();
+        _cache = new Mock<ICacheService>();
+        _health = new Mock<IHostHealthService>();
+        _health.Setup(h => h.RecordFailure(It.IsAny<string>())).Returns(Task.CompletedTask);
+        _health.Setup(h => h.RecordSuccess(It.IsAny<string>())).Returns(Task.CompletedTask);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { /* best effort */ }
+    }
+
+    [Test]
+    public async Task UnhealthyHost_SkipsJobWithoutDownloading()
+    {
+        _health.Setup(h => h.IsHostUnhealthy(HOST)).ReturnsAsync(true);
+
+        var downloadAttempted = false;
+        var download = BuildDownloadService(_ =>
+        {
+            downloadAttempted = true;
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([1, 2, 3, 4]) };
+        });
+
+        await RunUntilSecondDequeue(download);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(downloadAttempted, Is.False, "download must be skipped for an unhealthy host");
+            _health.Verify(h => h.RecordSuccess(It.IsAny<string>()), Times.Never);
+            _health.Verify(h => h.RecordFailure(It.IsAny<string>()), Times.Never);
+        });
+        _health.Verify(h => h.IsHostUnhealthy(HOST), Times.AtLeastOnce);
+    }
+
+    [Test]
+    public async Task HealthyHost_DownloadFails_RecordsFailure()
+    {
+        _health.Setup(h => h.IsHostUnhealthy(HOST)).ReturnsAsync(false);
+
+        var download = BuildDownloadService(_ => throw new HttpRequestException("connection refused"));
+
+        await RunUntilSecondDequeue(download);
+
+        _health.Verify(h => h.RecordFailure(HOST), Times.Once);
+        _health.Verify(h => h.RecordSuccess(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HealthyHost_DownloadSucceeds_RecordsSuccess()
+    {
+        _health.Setup(h => h.IsHostUnhealthy(HOST)).ReturnsAsync(false);
+
+        // Download succeeds; conversion then fails (no toktx/ffmpeg + unrecognized content),
+        // which is irrelevant here — success is recorded as soon as the download completes.
+        var download = BuildDownloadService(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([1, 2, 3, 4]) });
+
+        await RunUntilSecondDequeue(download);
+
+        _health.Verify(h => h.RecordSuccess(HOST), Times.Once);
+        _health.Verify(h => h.RecordFailure(It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Starts the service, returns the first job once, signals completion when the loop comes back
+    /// for a second job (i.e. the first was fully processed), then stops the service.
+    /// </summary>
+    private async Task RunUntilSecondDequeue(DownloadService download)
+    {
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+
+        _queue.Setup(q => q.Dequeue(It.IsAny<CancellationToken>()))
+            .Returns((CancellationToken token) => DequeueAsync(token));
+
+        async Task<ConversionJob> DequeueAsync(CancellationToken token)
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                return _job;
+            }
+
+            completed.TrySetResult();
+            await Task.Delay(Timeout.Infinite, token);
+            return _job; // unreachable; cancelled on StopAsync
+        }
+
+        var converter = new ConverterService(_tempDir, new FileAnalyzerService(),
+            NullLogger<ConverterService>.Instance);
+
+        var service = new ConversionBackgroundService(
+            _queue.Object, converter, download, _cache.Object, _health.Object,
+            concurrentConversions: 1, NullLogger<ConversionBackgroundService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        var finished = await Task.WhenAny(completed.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.That(finished, Is.SameAs(completed.Task), "service did not process the job within the timeout");
+    }
+
+    private DownloadService BuildDownloadService(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        var http = new HttpClient(new StubHandler(responder));
+        return new DownloadService(_tempDir, http, 50L * 1024 * 1024);
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(responder(request));
+        }
+    }
+}
+
+/// <summary>
+/// Tests that the download honors the cancellation token threaded through from the worker.
+/// </summary>
+[TestFixture]
+public class DownloadServiceTests
+{
+    private string _tempDir = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "metamorph-dl-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { /* best effort */ }
+    }
+
+    [Test]
+    public void DownloadFile_WithCancelledToken_ThrowsOperationCanceled()
+    {
+        var http = new HttpClient(new ImmediateHandler());
+        var service = new DownloadService(_tempDir, http, 1024 * 1024);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await service.DownloadFile("https://example.com/asset.png", "hash", cts.Token));
+    }
+
+    private sealed class ImmediateHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3, 4])
+            });
+        }
+    }
+}

--- a/Tests/HostHealthServiceTests.cs
+++ b/Tests/HostHealthServiceTests.cs
@@ -1,0 +1,227 @@
+using MetaMorphAPI.Services;
+using MetaMorphAPI.Services.Cache;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using StackExchange.Redis;
+
+namespace Tests;
+
+/// <summary>
+/// Tests for the Redis-backed per-host circuit breaker.
+/// </summary>
+[TestFixture]
+public class RedisHostHealthServiceTests
+{
+    private const string HOST = "catalyst.dcl.one";
+    private const int THRESHOLD = 3;
+    private static readonly TimeSpan WINDOW = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan COOLDOWN = TimeSpan.FromSeconds(60);
+
+    private Mock<IDatabase> _redis = null!;
+    private RedisHostHealthService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _redis = new Mock<IDatabase>();
+        _service = new RedisHostHealthService(_redis.Object, THRESHOLD, WINDOW, COOLDOWN,
+            NullLogger<RedisHostHealthService>.Instance);
+    }
+
+    [Test]
+    public async Task IsHostUnhealthy_WhenCircuitKeyExists_ReturnsTrue()
+    {
+        _redis.Setup(r => r.KeyExistsAsync(
+                It.Is<RedisKey>(k => k == RedisKeys.GetUnhealthyHostKey(HOST)), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        Assert.That(await _service.IsHostUnhealthy(HOST), Is.True);
+    }
+
+    [Test]
+    public async Task IsHostUnhealthy_WhenCircuitKeyAbsent_ReturnsFalse()
+    {
+        _redis.Setup(r => r.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(false);
+
+        Assert.That(await _service.IsHostUnhealthy(HOST), Is.False);
+    }
+
+    [Test]
+    public async Task RecordSuccess_DeletesBothFailureAndCircuitKeys()
+    {
+        await _service.RecordSuccess(HOST);
+
+        _redis.Verify(r => r.KeyDeleteAsync(
+            It.Is<RedisKey[]>(keys =>
+                keys.Contains(RedisKeys.GetHostFailureKey(HOST)) &&
+                keys.Contains(RedisKeys.GetUnhealthyHostKey(HOST))),
+            It.IsAny<CommandFlags>()), Times.Once);
+    }
+
+    [Test]
+    public async Task RecordFailure_FirstFailure_StartsWindowAndDoesNotOpenCircuit()
+    {
+        _redis.Setup(r => r.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(1);
+
+        await _service.RecordFailure(HOST);
+
+        // Window TTL is (re)set on the failure.
+        _redis.Verify(r => r.KeyExpireAsync(
+            It.Is<RedisKey>(k => k == RedisKeys.GetHostFailureKey(HOST)),
+            It.IsAny<TimeSpan?>(), It.IsAny<ExpireWhen>(), It.IsAny<CommandFlags>()), Times.Once);
+
+        // Below threshold, the circuit stays closed.
+        _redis.Verify(r => r.StringSetAsync(
+            It.Is<RedisKey>(k => k == RedisKeys.GetUnhealthyHostKey(HOST)),
+            It.IsAny<RedisValue>(), It.IsAny<TimeSpan?>(), It.IsAny<When>()), Times.Never);
+    }
+
+    [Test]
+    public async Task RecordFailure_BelowThreshold_RefreshesWindowButDoesNotOpenCircuit()
+    {
+        _redis.Setup(r => r.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(2); // not the first failure, below threshold of 3
+
+        await _service.RecordFailure(HOST);
+
+        // The sliding window is refreshed on every failure (keeps the counter alive through an outage).
+        _redis.Verify(r => r.KeyExpireAsync(
+            It.Is<RedisKey>(k => k == RedisKeys.GetHostFailureKey(HOST)),
+            It.IsAny<TimeSpan?>(), It.IsAny<ExpireWhen>(), It.IsAny<CommandFlags>()), Times.Once);
+        // ...but the circuit stays closed below the threshold.
+        _redis.Verify(r => r.StringSetAsync(
+            It.Is<RedisKey>(k => k == RedisKeys.GetUnhealthyHostKey(HOST)),
+            It.IsAny<RedisValue>(), It.IsAny<TimeSpan?>(), It.IsAny<When>()), Times.Never);
+    }
+
+    [Test]
+    public async Task RecordFailure_ReachingThreshold_OpensCircuitWithCooldownTtl()
+    {
+        _redis.Setup(r => r.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(THRESHOLD);
+
+        await _service.RecordFailure(HOST);
+
+        _redis.Verify(r => r.StringSetAsync(
+            It.Is<RedisKey>(k => k == RedisKeys.GetUnhealthyHostKey(HOST)),
+            It.IsAny<RedisValue>(),
+            It.Is<TimeSpan?>(t => t == COOLDOWN),
+            It.IsAny<When>()), Times.Once);
+    }
+
+    [Test]
+    public async Task RecordFailure_AboveThreshold_KeepsCircuitOpen()
+    {
+        _redis.Setup(r => r.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(THRESHOLD + 4);
+
+        await _service.RecordFailure(HOST);
+
+        _redis.Verify(r => r.StringSetAsync(
+            It.Is<RedisKey>(k => k == RedisKeys.GetUnhealthyHostKey(HOST)),
+            It.IsAny<RedisValue>(), It.IsAny<TimeSpan?>(), It.IsAny<When>()), Times.Once);
+    }
+}
+
+/// <summary>
+/// Tests for the in-memory per-host circuit breaker used in single-process (local) mode.
+/// </summary>
+[TestFixture]
+public class InMemoryHostHealthServiceTests
+{
+    private const string HOST = "catalyst.dcl.one";
+
+    [Test]
+    public async Task UnknownHost_IsHealthy()
+    {
+        var service = new InMemoryHostHealthService(3, TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(60));
+        Assert.That(await service.IsHostUnhealthy(HOST), Is.False);
+    }
+
+    [Test]
+    public async Task BelowThreshold_StaysHealthy()
+    {
+        var service = new InMemoryHostHealthService(3, TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(60));
+
+        await service.RecordFailure(HOST);
+        await service.RecordFailure(HOST);
+
+        Assert.That(await service.IsHostUnhealthy(HOST), Is.False);
+    }
+
+    [Test]
+    public async Task ReachingThreshold_OpensCircuit()
+    {
+        var service = new InMemoryHostHealthService(3, TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(60));
+
+        await service.RecordFailure(HOST);
+        await service.RecordFailure(HOST);
+        await service.RecordFailure(HOST);
+
+        Assert.That(await service.IsHostUnhealthy(HOST), Is.True);
+    }
+
+    [Test]
+    public async Task ThresholdOfOne_OpensOnFirstFailure()
+    {
+        var service = new InMemoryHostHealthService(1, TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(60));
+
+        await service.RecordFailure(HOST);
+
+        Assert.That(await service.IsHostUnhealthy(HOST), Is.True);
+    }
+
+    [Test]
+    public async Task RecordSuccess_ClosesOpenCircuit()
+    {
+        var service = new InMemoryHostHealthService(1, TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(60));
+        await service.RecordFailure(HOST);
+        Assert.That(await service.IsHostUnhealthy(HOST), Is.True);
+
+        await service.RecordSuccess(HOST);
+
+        Assert.That(await service.IsHostUnhealthy(HOST), Is.False);
+    }
+
+    [Test]
+    public async Task OpenCircuit_ClosesAfterCooldownElapses()
+    {
+        var service = new InMemoryHostHealthService(1, TimeSpan.FromMinutes(5), TimeSpan.FromMilliseconds(150));
+        await service.RecordFailure(HOST);
+        Assert.That(await service.IsHostUnhealthy(HOST), Is.True);
+
+        await Task.Delay(350);
+
+        Assert.That(await service.IsHostUnhealthy(HOST), Is.False, "circuit should allow a probe after cooldown");
+    }
+
+    [Test]
+    public async Task FailuresWithinRefreshedWindow_AccumulateBeyondOriginalWindow()
+    {
+        // Each failure refreshes the window, so spaced-out failures keep accumulating even though
+        // their total span exceeds one window length (the "sticky through an outage" guarantee).
+        var service = new InMemoryHostHealthService(3, TimeSpan.FromMilliseconds(200), TimeSpan.FromSeconds(60));
+
+        await service.RecordFailure(HOST);  // t0
+        await Task.Delay(150);
+        await service.RecordFailure(HOST);  // ~t150 (< 200ms since previous, window refreshed)
+        await Task.Delay(100);
+        await service.RecordFailure(HOST);  // ~t250 (< 200ms since previous, but > 200ms total)
+
+        Assert.That(await service.IsHostUnhealthy(HOST), Is.True);
+    }
+
+    [Test]
+    public async Task FailuresOutsideWindow_DoNotAccumulate()
+    {
+        var service = new InMemoryHostHealthService(2, TimeSpan.FromMilliseconds(120), TimeSpan.FromSeconds(60));
+
+        await service.RecordFailure(HOST);
+        await Task.Delay(250); // first failure's window expires
+        await service.RecordFailure(HOST); // counter resets to 1, below threshold
+
+        Assert.That(await service.IsHostUnhealthy(HOST), Is.False);
+    }
+}

--- a/Tests/HostHealthServiceTests.cs
+++ b/Tests/HostHealthServiceTests.cs
@@ -18,12 +18,16 @@ public class RedisHostHealthServiceTests
     private static readonly TimeSpan COOLDOWN = TimeSpan.FromSeconds(60);
 
     private Mock<IDatabase> _redis = null!;
+    private Mock<ITransaction> _transaction = null!;
     private RedisHostHealthService _service = null!;
 
     [SetUp]
     public void SetUp()
     {
         _redis = new Mock<IDatabase>();
+        _transaction = new Mock<ITransaction>();
+        _transaction.Setup(t => t.ExecuteAsync(It.IsAny<CommandFlags>())).ReturnsAsync(true);
+        _redis.Setup(r => r.CreateTransaction(It.IsAny<object>())).Returns(_transaction.Object);
         _service = new RedisHostHealthService(_redis.Object, THRESHOLD, WINDOW, COOLDOWN,
             NullLogger<RedisHostHealthService>.Instance);
     }
@@ -60,17 +64,21 @@ public class RedisHostHealthServiceTests
     }
 
     [Test]
-    public async Task RecordFailure_FirstFailure_StartsWindowAndDoesNotOpenCircuit()
+    public async Task RecordFailure_FirstFailure_RefreshesWindowAtomicallyAndDoesNotOpenCircuit()
     {
-        _redis.Setup(r => r.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+        _transaction.Setup(t => t.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
             .ReturnsAsync(1);
 
         await _service.RecordFailure(HOST);
 
-        // Window TTL is (re)set on the failure.
-        _redis.Verify(r => r.KeyExpireAsync(
+        // INCR + window refresh happen atomically inside a single MULTI/EXEC.
+        _transaction.Verify(t => t.StringIncrementAsync(
+            It.Is<RedisKey>(k => k == RedisKeys.GetHostFailureKey(HOST)), It.IsAny<long>(), It.IsAny<CommandFlags>()),
+            Times.Once);
+        _transaction.Verify(t => t.KeyExpireAsync(
             It.Is<RedisKey>(k => k == RedisKeys.GetHostFailureKey(HOST)),
             It.IsAny<TimeSpan?>(), It.IsAny<ExpireWhen>(), It.IsAny<CommandFlags>()), Times.Once);
+        _transaction.Verify(t => t.ExecuteAsync(It.IsAny<CommandFlags>()), Times.Once);
 
         // Below threshold, the circuit stays closed.
         _redis.Verify(r => r.StringSetAsync(
@@ -81,13 +89,13 @@ public class RedisHostHealthServiceTests
     [Test]
     public async Task RecordFailure_BelowThreshold_RefreshesWindowButDoesNotOpenCircuit()
     {
-        _redis.Setup(r => r.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
-            .ReturnsAsync(2); // not the first failure, below threshold of 3
+        _transaction.Setup(t => t.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(2); // below threshold of 3
 
         await _service.RecordFailure(HOST);
 
         // The sliding window is refreshed on every failure (keeps the counter alive through an outage).
-        _redis.Verify(r => r.KeyExpireAsync(
+        _transaction.Verify(t => t.KeyExpireAsync(
             It.Is<RedisKey>(k => k == RedisKeys.GetHostFailureKey(HOST)),
             It.IsAny<TimeSpan?>(), It.IsAny<ExpireWhen>(), It.IsAny<CommandFlags>()), Times.Once);
         // ...but the circuit stays closed below the threshold.
@@ -99,7 +107,7 @@ public class RedisHostHealthServiceTests
     [Test]
     public async Task RecordFailure_ReachingThreshold_OpensCircuitWithCooldownTtl()
     {
-        _redis.Setup(r => r.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+        _transaction.Setup(t => t.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
             .ReturnsAsync(THRESHOLD);
 
         await _service.RecordFailure(HOST);
@@ -114,7 +122,7 @@ public class RedisHostHealthServiceTests
     [Test]
     public async Task RecordFailure_AboveThreshold_KeepsCircuitOpen()
     {
-        _redis.Setup(r => r.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+        _transaction.Setup(t => t.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
             .ReturnsAsync(THRESHOLD + 4);
 
         await _service.RecordFailure(HOST);


### PR DESCRIPTION
## Summary
When a custom realm points the Explorer at a catalyst that is down or unreachable
(e.g. `catalyst.dcl.one`), every conversion job sourced from that host blocks a worker
slot for the full 100s `HttpClient` timeout. With one consumer per worker task, a single
dead host starves *all* conversions — healthy sources back up behind it, the SQS queue
grows, and users see unconverted textures/wearables across the board (observed ~87% of
worker capacity burned on guaranteed-fail downloads from one host).

This PR makes the worker isolate unreachable sources so one bad host can no longer
monopolize capacity.

## Root cause
- `HttpClient` is registered with no timeout override → the .NET default of 100s applies
  to downloads.
- `ConcurrentConversions: 1` → one in-flight download per task; a 100s hang freezes the
  whole task.
- Failed jobs are caught, logged, and dropped (no retry/DLQ), and the SQS message is
  deleted on dequeue. So this is **not** a self-recycling poison message — it's a
  **worker-slot poison**: each dead-host job costs ~100s of slot time, and fresh identical
  jobs keep arriving as the 10-min Redis dedup key expires and clients re-request.

## What this PR does
Two independent mechanisms, both in `MetaMorphAPI/Services`:

1. **Per-host circuit breaker** (`IHostHealthService`; Redis-backed in distributed mode,
   in-memory for local). The worker checks the source host before downloading; if the
   host's circuit is open it skips the job immediately. Because the SQS message is already
   deleted on dequeue, a skip is a clean drop — the same outcome as today's failure path,
   with the existing redirect-to-original behavior covering UX. Downloads record
   success/failure per host; N failures within a window open the circuit for a cooldown,
   after which a single probe re-tests. The failure window is refreshed on every failure,
   so the circuit stays tripped through a sustained outage instead of re-paying detection
   cost each window. State is shared across worker tasks via Redis.

2. **Connection-phase fast-fail** (`SocketsHttpHandler.ConnectTimeout`, 5s). Caps TCP/TLS
   connection establishment without shortening the overall transfer budget, so a host that
   won't accept connections fails in ~5s instead of 100s, while large but reachable
   downloads keep their full budget.

## Deliberately NOT changed
- **The 100s total `HttpClient.Timeout` is kept** — large legitimate files (up to
  `MaxDownloadFileSizeMB: 50`) may need it. `ConnectTimeout` targets the dead-host case
  specifically; the circuit breaker bounds every other failure mode regardless.
- **SQS visibility timeout, delete-on-dequeue, and DLQ** are untouched (out of scope; the
  visibility timeout is provisioned in infra, not in this repo).

## Config (added to `appsettings.json`; linked into the worker)
| Key | Default |
|---|---|
| `MetaMorph:ConnectTimeoutSeconds` | `5` |
| `MetaMorph:HostHealth:FailureThreshold` | `3` |
| `MetaMorph:HostHealth:FailureWindowSeconds` | `300` |
| `MetaMorph:HostHealth:CooldownSeconds` | `60` |

## Metrics
- `dcl_metamorph_download_skipped_total` — conversions skipped due to an open circuit.
  No host label, to avoid unbounded cardinality from arbitrary custom catalysts.

## Review fixes (addressed in follow-up commits)
- **Bookkeeping errors no longer mask download failures** — `RecordFailure` in the worker
  loop is wrapped; a breaker-side error (e.g. Redis unreachable) is logged as a warning and
  the original download exception is re-thrown intact.
- **Atomic failure counting** — the Redis `INCR` and window `EXPIRE` now run in a single
  MULTI/EXEC, so a crash between them can't leave the counter without a TTL. The conditional
  open stays a separate `SET` (a transaction can't branch on the INCR result); if a crash
  lands there the circuit simply opens on the next failure (benign, self-healing).
- **Bounded in-memory map** — the local in-memory breaker opportunistically evicts idle
  hosts once it exceeds 4096 entries, preventing unbounded growth under unique-host churn.
- Trailing-newline nit fixed.

## Testing
- New `Tests/HostHealthServiceTests.cs` — Redis and in-memory breaker logic, including the
  sticky-window behavior and atomic (MULTI/EXEC) failure counting.
- New `Tests/ConversionBackgroundServiceTests.cs` — worker skip / record-failure /
  record-success paths, plus download cancellation propagation.
- 19 tests, all passing. The only failing tests in the suite are the pre-existing
  `FileTypeTests` that shell out to `toktx`/`ffmpeg` (not installed in CI-less local runs)
  and are unaffected by this change.

## Caveats / follow-ups
- Not yet validated against a live unreachable host (the conversion path needs
  toktx/ffmpeg) — worth a staging smoke test against a known-down catalyst.
- When a cooldown expires, up to 3 worker slots may probe concurrently (bounded).
- `ConcurrentConversions: 1` is unchanged; raising it is a separate ops tuning that would
  further shrink blast radius.
